### PR TITLE
Adding methodOfPayment and fixing type items

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The ```participationFee``` building block is made up of three fields:
 * ```type``` - a value from the ```participationFeeType``` codelist, describing the type of the fee
 * ```value``` - the amount and currency of the fee
 * ```description``` - an optional field with more information on the fee requirements. For example, sometimes a document fee is only applicable to the hard copy of the documents.
+* ```methodOfPayment``` - an optional field providing information on methods of payment accepted for the documentation. This is currently an array of strings, but an open codelist may be introduced in future. 
 
 ## Extension codelists
 
@@ -42,15 +43,17 @@ The following JSON snippet models a contracting process where fees are applicabl
         "value": {
           "currency": "GBP",
           "amount": 8.00,
-          "description": "Fee payable for both soft and hard copies of documents. "
+          "description": "Fee payable for both soft and hard copies of documents."
+          "methodOfPayment":["electronic","cheque"]
         }
       },
       {
-        "type": "submission",
+        "type": ["submission"],
         "value": {
           "currency": "GBP",
           "amount": 10.00,
-          "description": "Fee payable within e-procurement system."
+          "description": "Fee payable within e-procurement system.",
+          "methodOfPayment":["electronic"]
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@ The following JSON snippet models a contracting process where fees are applicabl
         "type": "document",
         "value": {
           "currency": "GBP",
-          "amount": 8.00,
-          "description": "Fee payable for both soft and hard copies of documents.",
+          "amount": 8.00
+        },
+        "description": "Fee payable for both soft and hard copies of documents.",
           "methodOfPayment":["electronic","cheque"]
-        }
       },
       {
         "type": ["submission"],
         "value": {
           "currency": "GBP",
-          "amount": 10.00,
-          "description": "Fee payable within e-procurement system.",
-          "methodOfPayment":["electronic"]
-        }
+          "amount": 10.00
+        },
+        "description": "Fee payable within e-procurement system.",
+        "methodOfPayment":["electronic"]
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following JSON snippet models a contracting process where fees are applicabl
         "value": {
           "currency": "GBP",
           "amount": 8.00,
-          "description": "Fee payable for both soft and hard copies of documents."
+          "description": "Fee payable for both soft and hard copies of documents.",
           "methodOfPayment":["electronic","cheque"]
         }
       },

--- a/release-schema.json
+++ b/release-schema.json
@@ -31,9 +31,12 @@
           "type": "string"
         },
         "methodOfPayment":{
-          "title":"Method of payment",
+          "title":"Method(s) of payment",
           "description":"Optional information about the way in which fees can be paid.",
-          "type":"string"
+          "type":["array","null"],
+          "items":{
+            "type":"string"
+          }
         }
       }
     },

--- a/release-schema.json
+++ b/release-schema.json
@@ -1,6 +1,6 @@
 {
   "definitions": {
-    "participationFee": {
+    "ParticipationFee": {
       "title": "Participation fee",
       "type": "object",
       "properties": {
@@ -11,13 +11,16 @@
             "array",
             "null"
           ],
-          "enum": [
-            "document",
-            "deposit",
-            "submission",
-            "win",
-            null
-          ]
+          "items": {
+            "type": "string",
+            "enum": [
+              "document",
+              "deposit",
+              "submission",
+              "win",
+              null
+            ]
+          }
         },
         "value": {
           "$ref": "#/definitions/Value"
@@ -25,16 +28,12 @@
         "description": {
           "title": "Description",
           "description": "Optional information about the way in which fees are levied, or the exact nature of the fees.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "enum": [
-            "document",
-            "submission",
-            "win",
-            null
-          ]
+          "type": "string"
+        },
+        "methodOfPayment":{
+          "title":"Method of payment",
+          "description":"Optional information about the way in which fees can be paid.",
+          "type":"string"
         }
       }
     },
@@ -46,7 +45,7 @@
           "type": "array",
           "mergeStrategy": "ocdsVersion",
           "items": {
-            "$ref": "#/definitions/participationFee"
+            "$ref": "#/definitions/ParticipationFee"
           },
           "uniqueItems": true
         }


### PR DESCRIPTION
The EU mapping has highlighted the need for a ``methodOfPayment``` field, which I've added here as a simple string. There may be an optional open codelist for this in future. 

There were also some errors in the schema that I've addressed:

* The array of 'type' did not properly declare it's items;
* The description field had an incorrect type; 

@duncandewhurst could you review these changes and merge if they look alright to you. 

You may want to check if any implications for Nepal where I think we'd just suggested referencing this extension. 

