### PR TITLE
Correct ParticipationFee/type definition

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -12,7 +12,12 @@
             "null"
           ],
           "items": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
+            "codelist": "participationFeeType.csv",
+            "openCodelist": false,
             "enum": [
               "document",
               "deposit",


### PR DESCRIPTION
`participationFeeType.csv` exists and `enum` is set (and contains `null`) but the field is not nullable and the codelist fields are not set. This fixes those two issues.