### PR TITLE
making ParticipationFee.id required

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ## Changelog
 
+### Unreleased
+
+* Make `ParticipationFee.id` required so that participation fees are merged by identifier
+
 ### v1.1.5
 
 * Add `id` field to example in readme

--- a/release-schema.json
+++ b/release-schema.json
@@ -4,6 +4,9 @@
       "title": "Participation fee",
       "description": "A fee applicable to bidders wishing to participate in the tender process. Fees can apply for accessing bidding documents or for submitting bids, or there can be a \"win fee\" payable by the successful bidder.",
       "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
         "id": {
           "title": "Fee ID",
@@ -67,8 +70,7 @@
           "items": {
             "$ref": "#/definitions/ParticipationFee"
           },
-          "uniqueItems": true,
-          "wholeListMerge": true
+          "uniqueItems": true
         }
       }
     }


### PR DESCRIPTION
partially addresses for https://github.com/open-contracting/standard/issues/650

(deliberately haven't used a keyword as I assume the issue can't be closed until parts have been addressed)

